### PR TITLE
enabled objects to be returned for datatables-ajax

### DIFF
--- a/datatables-ajax.html
+++ b/datatables-ajax.html
@@ -56,9 +56,13 @@
 				if(columns.length>0){
 					this.data = response.data.map(function(currentValue){
 						var obj = {};
-						currentValue.forEach(function(element, i){
-							obj[columns[i].name] = element;
-						});
+						if (Object.prototype.toString.call(currentValue) === "[object Object]") {
+							obj = currentValue;
+						} else {
+							currentValue.forEach(function(element, i){
+								obj[columns[i].name] = element;
+							});
+						}
 						return obj;
 					});
 				}else this.data = response.data;


### PR DESCRIPTION
datatables-ajax previously only supported returning arrays, such as ["item1", "item2"]
Now, it can return objects from the server as well, like {"col1": "item1", "col2": "item2"}
